### PR TITLE
Use uglify-es instead of uglify-js

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var walkSync = require('walk-sync');
 var Plugin = require('broccoli-plugin');
-var UglifyJS = require('uglify-js');
+var UglifyJS = require('uglify-es');
 var path = require('path');
 var fs = require('fs');
 var defaults = require('lodash.defaultsdeep');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^0.5.0",
     "source-map-url": "^0.3.0",
     "symlink-or-copy": "^1.0.1",
-    "uglify-js": "^3.0.24",
+    "uglify-es": "^3.0.24",
     "walk-sync": "^0.1.3"
   },
   "devDependencies": {

--- a/test/expected/es6.js
+++ b/test/expected/es6.js
@@ -1,0 +1,2 @@
+class Foo{bar(){console.log(this.baz)}}let{bar:bar}=Foo.prototype;
+//# sourceMappingURL=es6.map

--- a/test/expected/es6.map
+++ b/test/expected/es6.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["0"],"names":["Foo","[object Object]","console","log","this","baz","bar","prototype"],"mappings":"MAAMA,IACJC,MACEC,QAAQC,IAAIC,KAAKC,MAIrB,IAAIC,IAAEA,KAAQN,IAAIO","file":"es6.js"}

--- a/test/fixtures/es6.js
+++ b/test/fixtures/es6.js
@@ -1,0 +1,7 @@
+class Foo {
+  bar() {
+    console.log(this.baz);
+  }
+}
+
+let { bar } = Foo.prototype;

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,15 @@ describe('broccoli-uglify-sourcemap', function() {
     });
   });
 
+  it('can handle ES6 code', function() {
+    var tree = new uglify(fixtures);
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(result) {
+      expectFile('es6.js').in(result);
+      expectFile('es6.map').in(result);
+    });
+  });
+
   it('can disable sourcemaps', function() {
     var tree = new uglify(fixtures, { uglify: { sourceMap: false } });
     builder = new broccoli.Builder(tree);

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,9 +486,9 @@ type-is@~1.5.1:
     media-typer "0.3.0"
     mime-types "~2.0.9"
 
-uglify-js@^3.0.24:
+uglify-es@^3.0.24:
   version "3.0.24"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.24.tgz#ee93400ad9857fb7a1671778db83f6a23f033121"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.0.24.tgz#fab5dccff6108df71d9573012ef65c740cb97cdc"
   dependencies:
     commander "~2.9.0"
     source-map "~0.5.1"


### PR DESCRIPTION
This is my attempt at changing this to use the latest 3.x uglify-es, which has support for ES2015. This addresses #46.

The expected test sourcemap changes are a copy & paste of the output, and I'm not certain if they are correct. From testing this on our ember apps, it looks like I get an output that makes sense when attempting to debug things in Chrome's dev tools.