### PR TITLE
remove sourceMappingURL if it doesn't have the same name with the js …

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,17 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
 
     if (srcURL.existsIn(src)) {
       let url = srcURL.getFrom(src);
+      let lastUrl = srcURL.getFrom(src);
+      // Make sure vendor.map is being used because vendor.js can have multiple sourceMappingURL if modules also have it.
+      while (url && url.match(/.+?(?=\.map$)/)[0] !== relativePath.match(/(.*\/)?(.+)\.js/)[2]) {
+        src = srcURL.removeFrom(src)
+        url = srcURL.getFrom(src);
+      }
+      // If there is no map url which has an identical name with the js file, use the last one.
+      // It's possible we should rather raise an error instead.
+      if (!url) {
+        url = lastUrl;
+      }
       let sourceMapPath = path.join(path.dirname(inFile), url);
       if (fs.existsSync(sourceMapPath)) {
         sourceMap.content = JSON.parse(fs.readFileSync(sourceMapPath));


### PR DESCRIPTION
- vendor.js file can have multiple `sourceMappingURL` locations when modules have their own `sourceMappingURL`. `source-map-url` module finds only one `sourceMappingURL` at a time. This PR removes sourceMappingURL if it doesn't have the same name with the js file until it finds the correct one.

- Use the last map file if there is no map file with the same name with the js file. This is possibly wrong and it might rather be correct to raise an error in such case.