### PR TITLE
Do not try to access `length` of minified code if minification failed

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,8 +116,6 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
   var result = UglifyJS.minify(src, options);
   var end = new Date();
   var total = end - start;
-  debug('[finished]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
-
   if (total > 20000 && !silent) {
     console.warn('[WARN] (broccoli-uglify-sourcemap) Minifying: `' + relativePath + '` took: ' + total + 'ms (more than 20,000ms)');
   }
@@ -126,6 +124,8 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
     result.error.filename = relativePath;
     throw result.error;
   }
+
+  debug('[finished]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
 
   if (options.sourceMap) {
     var newSourceMap = JSON.parse(result.map);


### PR DESCRIPTION
If `UglifyJS.minify(src, options)` (line 116) fails, the `result` object will have the following form:

```js
{
  error: [uglifyjs stack trace]
}
```

In this case, attempting to access `result.code.length` causes broccoli to fail with `Cannot read property 'length' of undefined`, and the error report file shows only the stack trace for this error, not the actual minification error.

Moving the `debug` line below the `throw` ensures that the user sees the real cause of the error (the uglifyjs stack trace) in the console and error report file.


---

Happy to add example or test if necessary - discovered during a long broccoli debugging session...