### PR TITLE
Run uglify in parallel, using a workerpool

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ var mkdirp = require('mkdirp');
 var srcURL = require('source-map-url');
 var MatcherCollection = require('matcher-collection');
 var debug = require('debug')('broccoli-uglify-sourcemap');
+var queue = require('async-promise-queue');
+var workerpool  = require('workerpool');
+
+var processFile = require('./lib/process-file');
 
 module.exports = UglifyWriter;
 
@@ -18,6 +22,8 @@ UglifyWriter.prototype = Object.create(Plugin.prototype);
 UglifyWriter.prototype.constructor = UglifyWriter;
 
 const silent = process.argv.indexOf('--silent') !== -1;
+
+const worker = queue.async.asyncify((doWork) => doWork());
 
 function UglifyWriter (inputNodes, options) {
   if (!(this instanceof UglifyWriter)) {
@@ -33,6 +39,14 @@ function UglifyWriter (inputNodes, options) {
       sourceMap: {},
     },
   });
+
+  // consumers of this plugin can opt-in to async and concurrent behavior
+  // TODO docs in the README
+  this.async = (this.options.async === true);
+  this.concurrency = this.options.concurrency || Number(process.env.JOBS) || Math.max(require('os').cpus().length - 1, 1);
+
+  // create a worker pool using an external worker script
+  this.pool = workerpool.pool(path.join(__dirname, 'lib', 'worker.js'), { maxWorkers: this.concurrency });
 
   this.inputNodes = inputNodes;
 
@@ -53,6 +67,9 @@ var MatchNothing = {
 UglifyWriter.prototype.build = function () {
   var writer = this;
 
+  // when options.async === true, allow processFile() operations to complete asynchronously
+  var pendingWork = [];
+
   this.inputPaths.forEach(function(inputPath) {
     walkSync(inputPath).forEach(function(relativePath) {
       if (relativePath.slice(-1) === '/') {
@@ -64,7 +81,15 @@ UglifyWriter.prototype.build = function () {
       mkdirp.sync(path.dirname(outFile));
 
       if (relativePath.slice(-3) === '.js' && !writer.excludes.match(relativePath)) {
-        writer.processFile(inFile, outFile, relativePath, writer.outputPath);
+        // wrap this in a function so it doesn't actually run yet, and can be throttled
+        var uglifyOperation = function() {
+          return writer.processFile(inFile, outFile, relativePath, writer.outputPath);
+        };
+        if (writer.async) {
+          pendingWork.push(uglifyOperation);
+          return;
+        }
+        return uglifyOperation();
       } else if (relativePath.slice(-4) === '.map') {
         if (writer.excludes.match(relativePath.slice(0, -4) + '.js')) {
           // ensure .map files for excluded JS paths are also copied forward
@@ -77,70 +102,18 @@ UglifyWriter.prototype.build = function () {
     });
   });
 
-  return this.outputPath;
+  return queue(worker, pendingWork, writer.concurrency)
+    .then((/* results */) => {
+      // files are finished processing, shut down the workers
+      writer.pool.terminate();
+      return writer.outputPath;
+    });
 };
 
 UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, outDir) {
-  var src = fs.readFileSync(inFile, 'utf-8');
-  var mapName = path.basename(outFile).replace(/\.js$/,'') + '.map';
-
-  var mapDir;
-  if (this.options.sourceMapDir) {
-    mapDir = path.join(outDir, this.options.sourceMapDir);
-  } else {
-    mapDir = path.dirname(path.join(outDir, relativePath));
+  // don't run this in the workerpool if concurrency is disabled (can set JOBS <= 1)
+  if (this.async && this.concurrency > 1) {
+    return this.pool.exec('processFileParallel', [inFile, outFile, relativePath, outDir, silent, this.options]);
   }
-
-  let options = defaults({}, this.options.uglify);
-  if (options.sourceMap) {
-    let filename = path.basename(inFile);
-    let url = this.options.sourceMapDir ? '/' + path.join(this.options.sourceMapDir, mapName) : mapName;
-
-    let sourceMap = { filename, url };
-
-    if (srcURL.existsIn(src)) {
-      let url = srcURL.getFrom(src);
-      let sourceMapPath = path.join(path.dirname(inFile), url);
-      if (fs.existsSync(sourceMapPath)) {
-        sourceMap.content = JSON.parse(fs.readFileSync(sourceMapPath));
-      } else if (!silent) {
-        console.warn(`[WARN] (broccoli-uglify-sourcemap) "${url}" referenced in "${relativePath}" could not be found`);
-      }
-    }
-
-    options = defaults(options, { sourceMap });
-  }
-
-  var start = new Date();
-  debug('[starting]: %s %dKB', relativePath, (src.length / 1000));
-  var result = UglifyJS.minify(src, options);
-  var end = new Date();
-  var total = end - start;
-  if (total > 20000 && !silent) {
-    console.warn('[WARN] (broccoli-uglify-sourcemap) Minifying: `' + relativePath + '` took: ' + total + 'ms (more than 20,000ms)');
-  }
-
-  if (result.error) {
-    result.error.filename = relativePath;
-    throw result.error;
-  }
-
-  debug('[finished]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
-
-  if (options.sourceMap) {
-    var newSourceMap = JSON.parse(result.map);
-
-    newSourceMap.sources = newSourceMap.sources.map(function(path){
-      // If out output file has the same name as one of our original
-      // sources, they will shadow eachother in Dev Tools. So instead we
-      // alter the reference to the upstream file.
-      if (path === relativePath) {
-        path = path.replace(/\.js$/, '-orig.js');
-      }
-      return path;
-    });
-    mkdirp.sync(mapDir);
-    fs.writeFileSync(path.join(mapDir, mapName), JSON.stringify(newSourceMap));
-  }
-  fs.writeFileSync(outFile, result.code);
+  return processFile(inFile, outFile, relativePath, outDir, silent, this.options);
 };

--- a/index.js
+++ b/index.js
@@ -107,12 +107,18 @@ UglifyWriter.prototype.build = function () {
       // files are finished processing, shut down the workers
       writer.pool.terminate();
       return writer.outputPath;
+    })
+    .catch((e) => {
+      // make sure to shut down the workers on error
+      writer.pool.terminate();
+      throw e;
     });
 };
 
 UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, outDir) {
   // don't run this in the workerpool if concurrency is disabled (can set JOBS <= 1)
   if (this.async && this.concurrency > 1) {
+    // each of these arguments is a string, which can be sent to the worker process as-is
     return this.pool.exec('processFileParallel', [inFile, outFile, relativePath, outDir, silent, this.options]);
   }
   return processFile(inFile, outFile, relativePath, outDir, silent, this.options);

--- a/lib/process-file.js
+++ b/lib/process-file.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var debug = require('debug')('broccoli-uglify-sourcemap');
+var defaults = require('lodash.defaultsdeep');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var path = require('path');
+var srcURL = require('source-map-url');
+
+var Promise = require('rsvp').Promise;
+var UglifyJS = require('uglify-es');
+
+
+// each of these is a string, so that's good
+module.exports = function processFile(inFile, outFile, relativePath, outDir, silent, _options) {
+  return new Promise((resolve, reject) => {
+
+    var src = fs.readFileSync(inFile, 'utf-8');
+    var mapName = path.basename(outFile).replace(/\.js$/,'') + '.map';
+
+    var mapDir;
+    if (_options.sourceMapDir) {
+      mapDir = path.join(outDir, _options.sourceMapDir);
+    } else {
+      mapDir = path.dirname(path.join(outDir, relativePath));
+    }
+
+    let options = defaults({}, _options.uglify);
+    if (options.sourceMap) {
+      let filename = path.basename(inFile);
+      let url = _options.sourceMapDir ? '/' + path.join(_options.sourceMapDir, mapName) : mapName;
+
+      let sourceMap = { filename, url };
+
+      if (srcURL.existsIn(src)) {
+        let url = srcURL.getFrom(src);
+        let sourceMapPath = path.join(path.dirname(inFile), url);
+        if (fs.existsSync(sourceMapPath)) {
+          sourceMap.content = JSON.parse(fs.readFileSync(sourceMapPath));
+        } else if (!silent) {
+          console.warn(`[WARN] (broccoli-uglify-sourcemap) "${url}" referenced in "${relativePath}" could not be found`);
+        }
+      }
+
+      options = defaults(options, { sourceMap });
+    }
+
+    var start = new Date();
+    debug('[starting]: %s %dKB', relativePath, (src.length / 1000));
+    var result = UglifyJS.minify(src, options);
+    var end = new Date();
+    var total = end - start;
+    if (total > 20000 && !silent) {
+      console.warn('[WARN] (broccoli-uglify-sourcemap) Minifying: `' + relativePath + '` took: ' + total + 'ms (more than 20,000ms)');
+    }
+
+    if (result.error) {
+      result.error.filename = relativePath;
+      reject(result.error);
+      return;
+    }
+
+    debug('[finished]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
+
+    if (options.sourceMap) {
+      var newSourceMap = JSON.parse(result.map);
+
+      newSourceMap.sources = newSourceMap.sources.map(function(path){
+        // If out output file has the same name as one of our original
+        // sources, they will shadow eachother in Dev Tools. So instead we
+        // alter the reference to the upstream file.
+        if (path === relativePath) {
+          path = path.replace(/\.js$/, '-orig.js');
+        }
+        return path;
+      });
+      mkdirp.sync(mapDir);
+      fs.writeFileSync(path.join(mapDir, mapName), JSON.stringify(newSourceMap));
+    }
+    fs.writeFileSync(outFile, result.code);
+    resolve();
+  });
+};

--- a/lib/process-file.js
+++ b/lib/process-file.js
@@ -11,73 +11,67 @@ var Promise = require('rsvp').Promise;
 var UglifyJS = require('uglify-es');
 
 
-// each of these is a string, so that's good
 module.exports = function processFile(inFile, outFile, relativePath, outDir, silent, _options) {
-  return new Promise((resolve, reject) => {
+  var src = fs.readFileSync(inFile, 'utf-8');
+  var mapName = path.basename(outFile).replace(/\.js$/,'') + '.map';
 
-    var src = fs.readFileSync(inFile, 'utf-8');
-    var mapName = path.basename(outFile).replace(/\.js$/,'') + '.map';
+  var mapDir;
+  if (_options.sourceMapDir) {
+    mapDir = path.join(outDir, _options.sourceMapDir);
+  } else {
+    mapDir = path.dirname(path.join(outDir, relativePath));
+  }
 
-    var mapDir;
-    if (_options.sourceMapDir) {
-      mapDir = path.join(outDir, _options.sourceMapDir);
-    } else {
-      mapDir = path.dirname(path.join(outDir, relativePath));
-    }
+  let options = defaults({}, _options.uglify);
+  if (options.sourceMap) {
+    let filename = path.basename(inFile);
+    let url = _options.sourceMapDir ? '/' + path.join(_options.sourceMapDir, mapName) : mapName;
 
-    let options = defaults({}, _options.uglify);
-    if (options.sourceMap) {
-      let filename = path.basename(inFile);
-      let url = _options.sourceMapDir ? '/' + path.join(_options.sourceMapDir, mapName) : mapName;
+    let sourceMap = { filename, url };
 
-      let sourceMap = { filename, url };
-
-      if (srcURL.existsIn(src)) {
-        let url = srcURL.getFrom(src);
-        let sourceMapPath = path.join(path.dirname(inFile), url);
-        if (fs.existsSync(sourceMapPath)) {
-          sourceMap.content = JSON.parse(fs.readFileSync(sourceMapPath));
-        } else if (!silent) {
-          console.warn(`[WARN] (broccoli-uglify-sourcemap) "${url}" referenced in "${relativePath}" could not be found`);
-        }
+    if (srcURL.existsIn(src)) {
+      let url = srcURL.getFrom(src);
+      let sourceMapPath = path.join(path.dirname(inFile), url);
+      if (fs.existsSync(sourceMapPath)) {
+        sourceMap.content = JSON.parse(fs.readFileSync(sourceMapPath));
+      } else if (!silent) {
+        console.warn(`[WARN] (broccoli-uglify-sourcemap) "${url}" referenced in "${relativePath}" could not be found`);
       }
-
-      options = defaults(options, { sourceMap });
     }
 
-    var start = new Date();
-    debug('[starting]: %s %dKB', relativePath, (src.length / 1000));
-    var result = UglifyJS.minify(src, options);
-    var end = new Date();
-    var total = end - start;
-    if (total > 20000 && !silent) {
-      console.warn('[WARN] (broccoli-uglify-sourcemap) Minifying: `' + relativePath + '` took: ' + total + 'ms (more than 20,000ms)');
-    }
+    options = defaults(options, { sourceMap });
+  }
 
-    if (result.error) {
-      result.error.filename = relativePath;
-      reject(result.error);
-      return;
-    }
+  var start = new Date();
+  debug('[starting]: %s %dKB', relativePath, (src.length / 1000));
+  var result = UglifyJS.minify(src, options);
+  var end = new Date();
+  var total = end - start;
+  if (total > 20000 && !silent) {
+    console.warn('[WARN] (broccoli-uglify-sourcemap) Minifying: `' + relativePath + '` took: ' + total + 'ms (more than 20,000ms)');
+  }
 
-    debug('[finished]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
+  if (result.error) {
+    result.error.filename = relativePath;
+    throw result.error;
+  }
 
-    if (options.sourceMap) {
-      var newSourceMap = JSON.parse(result.map);
+  debug('[finished]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
 
-      newSourceMap.sources = newSourceMap.sources.map(function(path){
-        // If out output file has the same name as one of our original
-        // sources, they will shadow eachother in Dev Tools. So instead we
-        // alter the reference to the upstream file.
-        if (path === relativePath) {
-          path = path.replace(/\.js$/, '-orig.js');
-        }
-        return path;
-      });
-      mkdirp.sync(mapDir);
-      fs.writeFileSync(path.join(mapDir, mapName), JSON.stringify(newSourceMap));
-    }
-    fs.writeFileSync(outFile, result.code);
-    resolve();
-  });
+  if (options.sourceMap) {
+    var newSourceMap = JSON.parse(result.map);
+
+    newSourceMap.sources = newSourceMap.sources.map(function(path){
+      // If out output file has the same name as one of our original
+      // sources, they will shadow eachother in Dev Tools. So instead we
+      // alter the reference to the upstream file.
+      if (path === relativePath) {
+        path = path.replace(/\.js$/, '-orig.js');
+      }
+      return path;
+    });
+    mkdirp.sync(mapDir);
+    fs.writeFileSync(path.join(mapDir, mapName), JSON.stringify(newSourceMap));
+  }
+  fs.writeFileSync(outFile, result.code);
 };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var workerpool = require('workerpool');
+
+var processFile = require('./process-file');
+
+// TODO - with an option to disable this parallelism
+function processFileParallel(inFile, outFile, relativePath, outDir, silent, _options) {
+  return processFile(inFile, outFile, relativePath, outDir, silent, _options);
+}
+
+// create worker and register public functions
+workerpool.worker({
+  processFileParallel
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "license": "MIT",
   "author": "Edward Faulkner <ef@alum.mit.edu>",
   "files": [
-    "index.js"
+    "index.js",
+    "lib"
   ],
   "main": "index.js",
   "repository": {
@@ -22,6 +23,7 @@
     "test:watch": "jest --watchAll"
   },
   "dependencies": {
+    "async-promise-queue": "^1.0.4",
     "broccoli-plugin": "^1.2.1",
     "debug": "^3.1.0",
     "lodash.defaultsdeep": "^4.6.0",
@@ -30,7 +32,8 @@
     "source-map-url": "^0.4.0",
     "symlink-or-copy": "^1.0.1",
     "uglify-es": "^3.1.3",
-    "walk-sync": "^0.3.2"
+    "walk-sync": "^0.3.2",
+    "workerpool": "^2.3.0"
   },
   "devDependencies": {
     "babel-jest": "^21.2.0",
@@ -53,6 +56,7 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/tmp"
     ],
+    "testEnvironment": "node",
     "testMatch": [
       "<rootDir>/test/test.js"
     ],

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -98,6 +98,31 @@ Object {
 }
 `;
 
+exports[`broccoli-uglify-sourcemap on error rejects with BuildError 1`] = `Object {}`;
+
+exports[`broccoli-uglify-sourcemap on error rejects with BuildError async 1`] = `Object {}`;
+
+exports[`broccoli-uglify-sourcemap on error shuts down the workerpool 1`] = `Object {}`;
+
+exports[`broccoli-uglify-sourcemap shuts down the workerpool 1`] = `
+Object {
+  "inside": Object {
+    "with-upstream-sourcemap.js": "function meaningOfLife(){throw new Error(42)}function boom(){throw new Error(\\"boom\\")}function somethingElse(){throw new Error(\\"somethign else\\")}function fourth(){throw new Error(\\"fourth\\")}function third(){throw new Error(\\"oh no\\")}
+//# sourceMappingURL=with-upstream-sourcemap.map",
+    "with-upstream-sourcemap.map": "{\\"version\\":3,\\"sources\\":[\\"/inner/first.js\\",\\"/inner/second.js\\",\\"/other/fourth.js\\",\\"/other/third.js\\"],\\"names\\":[\\"meaningOfLife\\",\\"Error\\",\\"boom\\",\\"somethingElse\\",\\"fourth\\",\\"third\\"],\\"mappings\\":\\"AAAA,SAAAA,gBAEA,MAAA,IAAAC,MADA,IAIA,SAAAC,OACA,MAAA,IAAAD,MAAA,QCNA,SAAAE,gBACA,MAAA,IAAAF,MAAA,kBCEA,SAAAG,SACA,MAAA,IAAAH,MAAA,UCJA,SAAAI,QACA,MAAA,IAAAJ,MAAA\\",\\"file\\":\\"with-upstream-sourcemap.js\\",\\"sourcesContent\\":[\\"function meaningOfLife() {\\\\n  var thisIsALongLocal = 42;\\\\n  throw new Error(thisIsALongLocal);\\\\n}\\\\n\\\\nfunction boom() {\\\\n  throw new Error('boom');\\\\n}\\\\n\\",\\"function somethingElse() {\\\\n  throw new Error(\\\\\\"somethign else\\\\\\");\\\\n}\\\\n\\",\\"\\\\n// Hello world\\\\n\\\\nfunction fourth(){\\\\n  throw new Error('fourth');\\\\n}\\\\n\\",\\"function third(){\\\\n  throw new Error(\\\\\\"oh no\\\\\\");\\\\n}\\\\n\\"]}",
+  },
+  "no-upstream-sourcemap.js": "function meaningOfLife(){throw new Error(42)}function boom(){throw new Error(\\"boom\\")}function somethingElse(){throw new Error(\\"somethign else\\")}function fourth(){throw new Error(\\"fourth\\")}function third(){throw new Error(\\"oh no\\")}
+//# sourceMappingURL=no-upstream-sourcemap.map",
+  "no-upstream-sourcemap.map": "{\\"version\\":3,\\"sources\\":[\\"0\\"],\\"names\\":[\\"meaningOfLife\\",\\"Error\\",\\"boom\\",\\"somethingElse\\",\\"fourth\\",\\"third\\"],\\"mappings\\":\\"AACA,SAASA,gBAEP,MAAM,IAAIC,MADa,IAIzB,SAASC,OACP,MAAM,IAAID,MAAM,QAGlB,SAASE,gBACP,MAAM,IAAIF,MAAM,kBAMlB,SAASG,SACP,MAAM,IAAIH,MAAM,UAGlB,SAASI,QACP,MAAM,IAAIJ,MAAM\\",\\"file\\":\\"no-upstream-sourcemap.js\\"}",
+  "something.css": "#id {
+    background: white;
+}",
+  "with-broken-sourcemap.js": "function meaningOfLife(){throw new Error(42)}
+//# sourceMappingURL=with-broken-sourcemap.map",
+  "with-broken-sourcemap.map": "{\\"version\\":3,\\"sources\\":[\\"0\\"],\\"names\\":[\\"meaningOfLife\\",\\"Error\\"],\\"mappings\\":\\"AAAA,SAASA,gBAEP,MAAM,IAAIC,MADa\\",\\"file\\":\\"with-broken-sourcemap.js\\"}",
+}
+`;
+
 exports[`broccoli-uglify-sourcemap supports alternate sourcemap location 1`] = `
 Object {
   "inside": Object {

--- a/test/__snapshots__/test.js.snap
+++ b/test/__snapshots__/test.js.snap
@@ -79,6 +79,25 @@ Object {
 }
 `;
 
+exports[`broccoli-uglify-sourcemap generates expected output async 1`] = `
+Object {
+  "inside": Object {
+    "with-upstream-sourcemap.js": "function meaningOfLife(){throw new Error(42)}function boom(){throw new Error(\\"boom\\")}function somethingElse(){throw new Error(\\"somethign else\\")}function fourth(){throw new Error(\\"fourth\\")}function third(){throw new Error(\\"oh no\\")}
+//# sourceMappingURL=with-upstream-sourcemap.map",
+    "with-upstream-sourcemap.map": "{\\"version\\":3,\\"sources\\":[\\"/inner/first.js\\",\\"/inner/second.js\\",\\"/other/fourth.js\\",\\"/other/third.js\\"],\\"names\\":[\\"meaningOfLife\\",\\"Error\\",\\"boom\\",\\"somethingElse\\",\\"fourth\\",\\"third\\"],\\"mappings\\":\\"AAAA,SAAAA,gBAEA,MAAA,IAAAC,MADA,IAIA,SAAAC,OACA,MAAA,IAAAD,MAAA,QCNA,SAAAE,gBACA,MAAA,IAAAF,MAAA,kBCEA,SAAAG,SACA,MAAA,IAAAH,MAAA,UCJA,SAAAI,QACA,MAAA,IAAAJ,MAAA\\",\\"file\\":\\"with-upstream-sourcemap.js\\",\\"sourcesContent\\":[\\"function meaningOfLife() {\\\\n  var thisIsALongLocal = 42;\\\\n  throw new Error(thisIsALongLocal);\\\\n}\\\\n\\\\nfunction boom() {\\\\n  throw new Error('boom');\\\\n}\\\\n\\",\\"function somethingElse() {\\\\n  throw new Error(\\\\\\"somethign else\\\\\\");\\\\n}\\\\n\\",\\"\\\\n// Hello world\\\\n\\\\nfunction fourth(){\\\\n  throw new Error('fourth');\\\\n}\\\\n\\",\\"function third(){\\\\n  throw new Error(\\\\\\"oh no\\\\\\");\\\\n}\\\\n\\"]}",
+  },
+  "no-upstream-sourcemap.js": "function meaningOfLife(){throw new Error(42)}function boom(){throw new Error(\\"boom\\")}function somethingElse(){throw new Error(\\"somethign else\\")}function fourth(){throw new Error(\\"fourth\\")}function third(){throw new Error(\\"oh no\\")}
+//# sourceMappingURL=no-upstream-sourcemap.map",
+  "no-upstream-sourcemap.map": "{\\"version\\":3,\\"sources\\":[\\"0\\"],\\"names\\":[\\"meaningOfLife\\",\\"Error\\",\\"boom\\",\\"somethingElse\\",\\"fourth\\",\\"third\\"],\\"mappings\\":\\"AACA,SAASA,gBAEP,MAAM,IAAIC,MADa,IAIzB,SAASC,OACP,MAAM,IAAID,MAAM,QAGlB,SAASE,gBACP,MAAM,IAAIF,MAAM,kBAMlB,SAASG,SACP,MAAM,IAAIH,MAAM,UAGlB,SAASI,QACP,MAAM,IAAIJ,MAAM\\",\\"file\\":\\"no-upstream-sourcemap.js\\"}",
+  "something.css": "#id {
+    background: white;
+}",
+  "with-broken-sourcemap.js": "function meaningOfLife(){throw new Error(42)}
+//# sourceMappingURL=with-broken-sourcemap.map",
+  "with-broken-sourcemap.map": "{\\"version\\":3,\\"sources\\":[\\"0\\"],\\"names\\":[\\"meaningOfLife\\",\\"Error\\"],\\"mappings\\":\\"AAAA,SAASA,gBAEP,MAAM,IAAIC,MADa\\",\\"file\\":\\"with-broken-sourcemap.js\\"}",
+}
+`;
+
 exports[`broccoli-uglify-sourcemap supports alternate sourcemap location 1`] = `
 Object {
   "inside": Object {

--- a/test/fixtures-error/no-upstream-sourcemap.js
+++ b/test/fixtures-error/no-upstream-sourcemap.js
@@ -1,0 +1,3 @@
+/* This file has an error. */
+var i =
+

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,14 @@ describe('broccoli-uglify-sourcemap', function() {
     expect(builder.read()).toMatchSnapshot();
   });
 
+  it('generates expected output async', async function() {
+    builder = createBuilder(new uglify(fixtures, { async: true }));
+
+    await builder.build();
+
+    expect(builder.read()).toMatchSnapshot();
+  });
+
   it('can handle ES6 code', async function() {
     input.write({
       'es6.js': `class Foo {

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,6 +129,13 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
+async-promise-queue@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/async-promise-queue/-/async-promise-queue-1.0.4.tgz#308baafbc74aff66a0bb6e7f4a18d4fe8434440c"
+  dependencies:
+    async "^2.4.1"
+    debug "^2.6.8"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -136,6 +143,12 @@ async@^1.4.0:
 async@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  dependencies:
+    lodash "^4.14.0"
+
+async@^2.4.1:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
 
@@ -623,6 +636,12 @@ debug@^2.2.0:
   resolved "https://registry.npmjs.org/debug/-/debug-2.4.5.tgz#34c7b12a1ca96674428f41fe92c49b4ce7cd0607"
   dependencies:
     ms "0.7.2"
+
+debug@^2.6.8:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
 
 debug@^3.1.0:
   version "3.1.0"
@@ -1924,7 +1943,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@4.1.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2779,6 +2798,12 @@ worker-farm@^1.3.1:
   dependencies:
     errno "^0.1.4"
     xtend "^4.0.1"
+
+workerpool@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.0.tgz#86c5cbe946b55e7dc9d12b1936c8801a6e2d744d"
+  dependencies:
+    object-assign "4.1.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This converts uglify to run in parallel, using some of the same conventions as https://github.com/babel/broccoli-babel-transpiler/pull/114 and https://github.com/babel/broccoli-babel-transpiler/pull/127.

I had to change the test environment to use node, since otherwise jest uses the browser environment which fails for workerpool.

TODO:
* docs,
* debug logging
* unit test for processFile()

