### PR TITLE
Bugfix: JOBS environment variable should override concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,22 @@ var uglified = uglify(input);
 // advanced usage
 var uglified = uglify(input, {
   exclude: [..], // array of globs, to not minify
-  
+
   uglify: {
     mangle: false,    // defaults to true
     compress: false,  // defaults to true
     sourceMap: false, // defaults to true
     //...
-  }
+  },
+
+  async: true,   // run uglify in parallel, defaults to false
+  concurrency: 3 // number of parallel workers, defaults to number of CPUs - 1
 });
+```
+
+To disable parallelization:
+
+```
+$ JOBS=0
+$ JOBS=1
 ```

--- a/index.js
+++ b/index.js
@@ -118,8 +118,10 @@ UglifyWriter.prototype.build = function () {
 UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, outDir) {
   // don't run this in the workerpool if concurrency is disabled (can set JOBS <= 1)
   if (this.async && this.concurrency > 1) {
+    debug('running in workerpool, concurrency=%d', this.concurrency);
     // each of these arguments is a string, which can be sent to the worker process as-is
     return this.pool.exec('processFileParallel', [inFile, outFile, relativePath, outDir, silent, this.options]);
   }
+  debug('not running in workerpool');
   return processFile(inFile, outFile, relativePath, outDir, silent, this.options);
 };

--- a/index.js
+++ b/index.js
@@ -41,9 +41,8 @@ function UglifyWriter (inputNodes, options) {
   });
 
   // consumers of this plugin can opt-in to async and concurrent behavior
-  // TODO docs in the README
   this.async = (this.options.async === true);
-  this.concurrency = this.options.concurrency || Number(process.env.JOBS) || Math.max(require('os').cpus().length - 1, 1);
+  this.concurrency = Number(process.env.JOBS) || this.options.concurrency || Math.max(require('os').cpus().length - 1, 1);
 
   // create a worker pool using an external worker script
   this.pool = workerpool.pool(path.join(__dirname, 'lib', 'worker.js'), { maxWorkers: this.concurrency });

--- a/test/test.js
+++ b/test/test.js
@@ -127,6 +127,31 @@ let { bar } = Foo.prototype;`,
     });
   });
 
+  describe('concurrency', function() {
+    afterEach(function() {
+      delete process.env.JOBS;
+    });
+
+    it('defaults to CPUs-1 workers', async function() {
+      var testUglify = new uglify(fixturesError, { async: true });
+
+      expect(testUglify.concurrency).toEqual(require('os').cpus().length - 1);
+    });
+
+    it('sets concurrency using the option', async function() {
+      var testUglify = new uglify(fixturesError, { async: true, concurrency: 145 });
+
+      expect(testUglify.concurrency).toEqual(145);
+    });
+
+    it('overrides concurrency with JOBS env variable', async function() {
+      process.env.JOBS = '7';
+      var testUglify = new uglify(fixturesError, { async: true, concurrency: 145 });
+
+      expect(testUglify.concurrency).toEqual(7);
+    });
+  });
+
   afterEach(async function() {
     if (input) {
       await input.dispose();


### PR DESCRIPTION
Setting JOBS env var should override concurrency setting and detected number of CPUs. Fixed that and added tests, docs, and debug logging.