### PR TITLE
Drop Node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "stable"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "6"
+  - "8"
   - "10"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "6"
-  - "stable"
+  - "10"
 
 script:
   - yarn run test:coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "11"
 
 script:
   - yarn run test:coverage

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "jest-runner-eslint": "^0.6.0",
     "lerna-changelog": "^0.7.0"
   },
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
+  },
   "changelog": {
     "repo": "ember-cli/broccoli-uglify-sourcemap",
     "labels": {


### PR DESCRIPTION
... because Node 4 is no longer maintained by the Node.js team and several dependency updates are blocked because we still support Node 4.

This PR will require a new major version release.