### PR TITLE
Use updated workerpool option

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function UglifyWriter(inputNodes, options) {
   // create a worker pool using an external worker script
   this.pool = workerpool.pool(path.join(__dirname, 'lib', 'worker.js'), {
     maxWorkers: this.concurrency,
-    nodeWorker: 'auto',
+    workerType: 'auto',
   });
 
   this.inputNodes = inputNodes;


### PR DESCRIPTION
The following warning is visible due to the usage of the deprecated `nodeWorker` option in `workerpool` package.

```
WARNING: Option "nodeWorker" is deprecated since workerpool@5.0.0. Please use "workerType" instead.
```

This PR uses the option `workerType` instead.