### PR TITLE
bump workerpool to 6.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function UglifyWriter(inputNodes, options) {
   // create a worker pool using an external worker script
   this.pool = workerpool.pool(path.join(__dirname, 'lib', 'worker.js'), {
     maxWorkers: this.concurrency,
-    nodeWorker: 'auto',
+    workerType: 'auto',
   });
 
   this.inputNodes = inputNodes;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "symlink-or-copy": "^1.3.1",
     "terser": "^4.8.0",
     "walk-sync": "^1.1.3",
-    "workerpool": "^5.0.4"
+    "workerpool": "^6.0.0"
   },
   "devDependencies": {
     "babel-jest": "^23.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5457,10 +5457,10 @@ wordwrap@^1.0.0, wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-workerpool@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-5.0.4.tgz#4f67cb70ff7550a27ab94de25b0b843cd92059a2"
-  integrity sha512-Sywova24Ow2NQ24JPB68bI89EdqMDjUXo4OpofK/QMD7C2ZVMloYBgQ5J3PChcBJHj2vspsmGx1/3nBKXtUkXQ==
+workerpool@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
+  integrity sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
https://github.com/ember-cli/broccoli-uglify-sourcemap/issues/228

This PR removes the deprecation warning for `options.nodeWorker` (renamed to `options.workerType`)